### PR TITLE
MVP monoliith manifest added to backend

### DIFF
--- a/devops/kube/monolith-manifest.yml
+++ b/devops/kube/monolith-manifest.yml
@@ -1,0 +1,54 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata: 
+  name: forge-frontend-backend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: forge-frontend-backend
+  template:
+    metadata:
+      labels:
+        app: forge-frontend-backend
+    spec:
+      containers:
+      - name: forge-frontend
+        image: dajpearl/forge-frontend:latest
+        resources:
+          requests:
+            memory: "500Mi"
+            cpu: "100m"
+          limits:
+            memory: "1Gi"
+            cpu: "200m"
+      - name: forge-backend
+        image: dajpearl/forge-backend:latest
+        resources:
+          requests:
+            memory: "500Mi"
+            cpu: "100m"
+          limits:
+            memory: "1.5Gi"
+            cpu: "200m"
+        ports:
+        - containerPort: 3000
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontend-backend-service
+spec:
+  type: LoadBalancer
+  selector:
+    app: forge-frontend-backend
+  ports:
+  - port: 3000
+    name: frontend
+    protocol: TCP
+  - port: 8081
+    name: backend
+    protocol: TCP
+
+


### PR DESCRIPTION
The manifest works, and applying the manifest allows us to access both the frontend and backend components. The exact same manifest is copied in both the frontend and the backend so that both pipelines have access to it. This system will need to change later when the pipelines don't just push to the latest tag, but it works as a Minimum Viable Product.
