### PR TITLE
add backend k8 manifest

### DIFF
--- a/devops/kube/backend_manifest.yaml
+++ b/devops/kube/backend_manifest.yaml
@@ -1,8 +1,9 @@
 apiVersion: apps/v1
-kind: Deployment #statefulset?
-metadata:
+kind: Deployment
+metadata: 
   name: forge-backend
 spec:
+  replicas: 1
   selector:
     matchLabels:
       app: forge-backend
@@ -13,28 +14,27 @@ spec:
     spec:
       containers:
       - name: forge-backend
-        image: #placeholder/image:latest
+        image: dajpearl/forge-backend:latest
         resources:
           requests:
             memory: "500Mi"
-            cpu: "400m"
+            cpu: "100m"
           limits:
             memory: "1Gi"
-            cpu: "800m"
+            cpu: "200m"
         ports:
         - containerPort: 8081
-        # env:
-        # envFrom:
-        # - configmapRef:
+
 ---
 apiVersion: v1
 kind: Service
 metadata:
   name: backend-service
 spec:
+  type: LoadBalancer
   selector:
     app: forge-backend
   ports:
   - port: 8081
-    targetPort: 8081
+    name: backend
     protocol: TCP


### PR DESCRIPTION
Separated what was previously a monolith k8 manifest into backend and frontend. This is the backend deployment.