### PR TITLE
Fix user not being ignored in the JSON

### DIFF
--- a/devops/bundle/azure-pipelines.yml
+++ b/devops/bundle/azure-pipelines.yml
@@ -33,7 +33,7 @@ parameters:
     default: 'p3-team2-acr'
   - name: frontendBranchDefault
     type: string
-    default: 'refs/heads/main'
+    default: 'refs/heads/dev'
     # references the names of branches on another repo
 
 resources:

--- a/src/main/java/com/forge/revature/controllers/FullPortfolioIgnoreMixin.java
+++ b/src/main/java/com/forge/revature/controllers/FullPortfolioIgnoreMixin.java
@@ -1,0 +1,14 @@
+package com.forge.revature.controllers;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.forge.revature.models.User;
+
+import java.util.HashMap;
+
+public abstract class FullPortfolioIgnoreMixin {
+    @JsonIgnore
+    User user;
+
+    @JsonIgnore
+    HashMap<String, String> flags;
+}

--- a/src/main/java/com/forge/revature/controllers/PortfolioController.java
+++ b/src/main/java/com/forge/revature/controllers/PortfolioController.java
@@ -9,7 +9,6 @@ import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 import javax.servlet.http.HttpServletResponse;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.forge.revature.models.*;

--- a/src/main/java/com/forge/revature/controllers/PortfolioController.java
+++ b/src/main/java/com/forge/revature/controllers/PortfolioController.java
@@ -39,12 +39,10 @@ abstract class PortfolioIgnoreMixin {
     Portfolio portfolio;
 }
 
-abstract class UserIgnoreMixin {
+abstract class FullPortfolioIgnoreMixin {
     @JsonIgnore
     User user;
-}
 
-abstract class FlagIgnoreMixin {
     @JsonIgnore
     HashMap<String, String> flags;
 }
@@ -189,8 +187,7 @@ public class PortfolioController {
         );
 
         ObjectMapper mapper = new ObjectMapper();
-        mapper.addMixIn(FullPortfolio.class, UserIgnoreMixin.class);
-        mapper.addMixIn(FullPortfolio.class, FlagIgnoreMixin.class);
+        mapper.addMixIn(FullPortfolio.class, FullPortfolioIgnoreMixin.class);
         mapper.addMixIn(AboutMe.class, PortfolioIgnoreMixin.class);
         mapper.addMixIn(Certification.class, PortfolioIgnoreMixin.class);
         mapper.addMixIn(Education.class, PortfolioIgnoreMixin.class);

--- a/src/main/java/com/forge/revature/controllers/PortfolioController.java
+++ b/src/main/java/com/forge/revature/controllers/PortfolioController.java
@@ -34,19 +34,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-abstract class PortfolioIgnoreMixin {
-    @JsonIgnore
-    Portfolio portfolio;
-}
-
-abstract class FullPortfolioIgnoreMixin {
-    @JsonIgnore
-    User user;
-
-    @JsonIgnore
-    HashMap<String, String> flags;
-}
-
 @RestController
 @CrossOrigin(origins = "http://localhost:3000")
 @RequestMapping("api/portfolios")

--- a/src/main/java/com/forge/revature/controllers/PortfolioIgnoreMixin.java
+++ b/src/main/java/com/forge/revature/controllers/PortfolioIgnoreMixin.java
@@ -1,0 +1,9 @@
+package com.forge.revature.controllers;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.forge.revature.models.Portfolio;
+
+public abstract class PortfolioIgnoreMixin {
+    @JsonIgnore
+    Portfolio portfolio;
+}

--- a/src/test/java/com/forge/revature/demo/PortfolioTest.java
+++ b/src/test/java/com/forge/revature/demo/PortfolioTest.java
@@ -309,7 +309,7 @@ public class PortfolioTest {
         }
 
         FullPortfolioIgnoreMixinImpl fp = new FullPortfolioIgnoreMixinImpl();
-	    assertEquals(fp.portfolio, null);
+	    assertEquals(null, fp.portfolio);
     }
 
     @Test
@@ -319,7 +319,7 @@ public class PortfolioTest {
         }
 
         PortfolioIgnoreMixinImpl fp = new PortfolioIgnoreMixinImpl();
-        assertEquals(fp.portfolio, null);
+        assertEquals(null, fp.portfolio);
     }
 
 }

--- a/src/test/java/com/forge/revature/demo/PortfolioTest.java
+++ b/src/test/java/com/forge/revature/demo/PortfolioTest.java
@@ -1,5 +1,6 @@
 package com.forge.revature.demo;
 
+import static org.junit.Assert.assertEquals;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -14,6 +15,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
 
+import com.forge.revature.controllers.FullPortfolioIgnoreMixin;
+import com.forge.revature.controllers.PortfolioIgnoreMixin;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -298,4 +301,25 @@ public class PortfolioTest {
 		mvc.perform(post(baseUrl + "/full").contentType(MediaType.APPLICATION_JSON)
 				.content(om.writeValueAsString(testFullPortfolio))).andExpect(status().isOk());
 	}
+
+	@Test
+    void testFullPortfolioMixinIgnore() {
+	    class FullPortfolioIgnoreMixinImpl extends FullPortfolioIgnoreMixin {
+	        Portfolio portfolio;
+        }
+
+        FullPortfolioIgnoreMixinImpl fp = new FullPortfolioIgnoreMixinImpl();
+	    assertEquals(fp.portfolio, null);
+    }
+
+    @Test
+    void testPortfolioIgnoreMixin() {
+        class PortfolioIgnoreMixinImpl extends PortfolioIgnoreMixin {
+            Portfolio portfolio;
+        }
+
+        PortfolioIgnoreMixinImpl fp = new PortfolioIgnoreMixinImpl();
+        assertEquals(fp.portfolio, null);
+    }
+
 }


### PR DESCRIPTION
The User object was not being ignored and was included inside the JSON export response. Adding multiple mixins to an ObjectMapper does not work so they were combined into a single JSON ignore mixin.