### PR TITLE
Bundle pipelines now can pull from places other than main.

### DIFF
--- a/devops/bundle/azure-pipelines.yml
+++ b/devops/bundle/azure-pipelines.yml
@@ -58,11 +58,7 @@ stages:
               buildVersionToDownload: 'latestFromBranch'
               branchName: 'refs/heads/bundle'
               artifactName: 'static'
-              targetPath: '$(Build.Repository.LocalPath)/src/main/resources/'
-
-          - script: |
-              find
-            displayName: debug
+              targetPath: '$(Build.Repository.LocalPath)/src/main/resources/static'
           
           - task: SonarCloudPrepare@1
             inputs:
@@ -76,7 +72,7 @@ stages:
 
           - task: Maven@3
             inputs:
-              mavenPomFile: 'Forge-Backend/pom.xml'
+              mavenPomFile: 'pom.xml'
               publishJUnitResults: true
               testResultsFiles: '**/surefire-reports/TEST-*.xml'
               codeCoverageToolOption: 'JaCoCo'
@@ -93,7 +89,7 @@ stages:
             
           - task: PublishPipelineArtifact@1
             inputs:
-              targetPath: '$(Build.Repository.LocalPath)/Forge-Backend/target/demo-0.0.1-SNAPSHOT.war'
+              targetPath: '$(Build.Repository.LocalPath)/target/demo-0.0.1-SNAPSHOT.war'
               artifact: 'bundle-jar'
               publishLocation: 'pipeline'
             displayName: Publish Maven output as artifact

--- a/devops/bundle/azure-pipelines.yml
+++ b/devops/bundle/azure-pipelines.yml
@@ -91,9 +91,9 @@ stages:
               mavenVersionOption: 'Default'
               mavenAuthenticateFeed: false
               effectivePomSkip: false
-              ${{ if eq( variables['Build.Reason'], "ResourceTrigger" )}}:
+              ${{ if eq( variables['Build.Reason'], 'ResourceTrigger' )}}:
                 sonarQubeRunAnalysis: false
-              ${{ if ne( variables['Build.Reason'], "ResourceTrigger" )}}:
+              ${{ if ne( variables['Build.Reason'], 'ResourceTrigger' )}}:
                 sonarQubeRunAnalysis: true
                 sqMavenPluginVersionChoice: 'pom'
               

--- a/devops/bundle/azure-pipelines.yml
+++ b/devops/bundle/azure-pipelines.yml
@@ -33,11 +33,14 @@ parameters:
     default: 'p3-team2-acr'
 
 resources:
- repositories:
-   - repository: forgeFrontend
-     type: github
-     endpoint: 1058-Sophia-Gavrila-Forge
-     name: 1058-Sophia-Gavrila-Forge/Portfolio-Frontend
+  pipelines:
+    - pipeline: pipe_bundle-front
+      source: Bundle-front
+      trigger:
+        branches:
+          include: 
+            - main
+            - dev
 
 stages:
   - stage: Build_and_Test
@@ -45,20 +48,21 @@ stages:
       - job: makeJar
         steps:
           - checkout: self
-          - checkout: forgeFrontend
           
-          - task: NodeTool@0
+          - task: DownloadPipelineArtifact@2
             inputs:
-              versionSpec: '14.x'
-            displayName: 'Install Node.js'
+              buildType: 'specific'
+              project: 'eb90657a-0d4f-4efc-ab88-854ac581c5a8'
+              definition: '191'
+              specificBuildWithTriggering: true
+              buildVersionToDownload: 'latestFromBranch'
+              branchName: 'refs/heads/dev'
+              artifactName: 'static'
+              targetPath: '$(Build.Repository.LocalPath)/src/main/resources/'
 
           - script: |
-              cd Portfolio-Frontend
-              npm install
-              npm run-script build
-              cd ..
-              cp -r ./Portfolio-Frontend/build ./Forge-Backend/src/main/resources/static
-            displayName: prepare for maven
+              find
+            displayName: debug
           
           - task: SonarCloudPrepare@1
             inputs:

--- a/devops/bundle/azure-pipelines.yml
+++ b/devops/bundle/azure-pipelines.yml
@@ -56,7 +56,7 @@ stages:
               definition: '191'
               specificBuildWithTriggering: true
               buildVersionToDownload: 'latestFromBranch'
-              branchName: 'refs/heads/dev'
+              branchName: 'refs/heads/bundle'
               artifactName: 'static'
               targetPath: '$(Build.Repository.LocalPath)/src/main/resources/'
 

--- a/devops/bundle/azure-pipelines.yml
+++ b/devops/bundle/azure-pipelines.yml
@@ -31,6 +31,10 @@ parameters:
   - name: 'secretName'
     type: string
     default: 'p3-team2-acr'
+  - name: frontendBranchDefault
+    type: string
+    default: 'refs/heads/main'
+    # references the names of branches on another repo
 
 resources:
   pipelines:
@@ -48,7 +52,7 @@ stages:
       - job: makeJar
         steps:
           - checkout: self
-          
+
           - task: DownloadPipelineArtifact@2
             inputs:
               buildType: 'specific'
@@ -56,7 +60,12 @@ stages:
               definition: '191'
               specificBuildWithTriggering: true
               buildVersionToDownload: 'latestFromBranch'
-              branchName: 'refs/heads/bundle'
+              ${{ if eq(variables['Build.SourceBranch'], parameters.branchMain) }}:
+                branchName: 'refs/heads/main' #hardcoded reference to frontend branches
+              ${{ if eq(variables['Build.SourceBranch'], parameters.branchDev) }}:
+                branchName: 'refs/heads/dev'  #hardcoded reference to frontend branches
+              ${{ if not(in( variables['Build.SourceBranch'], parameters.branchMain, parameters.branchDev )) }}:
+                branchName: ${{ parameters.frontendBranchDefault }}
               artifactName: 'static'
               targetPath: '$(Build.Repository.LocalPath)/src/main/resources/static'
           
@@ -82,9 +91,12 @@ stages:
               mavenVersionOption: 'Default'
               mavenAuthenticateFeed: false
               effectivePomSkip: false
-              sonarQubeRunAnalysis: true
-              sqMavenPluginVersionChoice: 'pom'
-
+              ${{ if eq( variables['Build.Reason'], "ResourceTrigger" )}}:
+                sonarQubeRunAnalysis: false
+              ${{ if ne( variables['Build.Reason'], "ResourceTrigger" )}}:
+                sonarQubeRunAnalysis: true
+                sqMavenPluginVersionChoice: 'pom'
+              
             displayName: Maven package, JUnit test, Sonar, JaCoCo
             
           - task: PublishPipelineArtifact@1


### PR DESCRIPTION
Relies on [Frontend PR](https://github.com/1058-Sophia-Gavrila-Forge/Portfolio-Frontend/pull/37), but changed logic to use build artifacts from frontend pipeline. Defaults to using the artifacts from main on branches other than main and dev, but main and dev will use the corresponding branches.

With this, we DevOps'ed the CORS error away without actually fixing the original refactoring problem. The bundle solution probably means that the two things should've been in the same repo, but well, we worked around that, and maybe someone will refactor and turn it into a microservice.